### PR TITLE
Rollback to use a FilterResponseEvent class

### DIFF
--- a/modules/webprofiler/src/EventListener/WebDebugToolbarListener.php
+++ b/modules/webprofiler/src/EventListener/WebDebugToolbarListener.php
@@ -9,7 +9,7 @@ use Drupal\webprofiler\Csp\ContentSecurityPolicyHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -87,10 +87,10 @@ class WebDebugToolbarListener implements EventSubscriberInterface {
   /**
    * Listen for the kernel.response event.
    *
-   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
    *   A response event.
    */
-  public function onKernelResponse(ResponseEvent $event) {
+  public function onKernelResponse(FilterResponseEvent $event) {
     $response = $event->getResponse();
     $request = $event->getRequest();
 


### PR DESCRIPTION
See https://trello.com/c/UvNMcUI8/42-webdebugtoolbarlisteneronkernelresponse-required-symfony-responseevent